### PR TITLE
Add mock admin center UI

### DIFF
--- a/mock_ui_admin_center_v1/index.html
+++ b/mock_ui_admin_center_v1/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Admin Center</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <div class="logo">Admin Center</div>
+        <div class="user">Hello, User</div>
+    </header>
+    <div class="container">
+        <nav class="side-nav">
+            <ul>
+                <li class="active">Dashboard</li>
+                <li>Users</li>
+                <li>Settings</li>
+            </ul>
+        </nav>
+        <main class="content">
+            <h1>Dashboard</h1>
+            <canvas id="statsCanvas" width="400" height="200"></canvas>
+        </main>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/mock_ui_admin_center_v1/script.js
+++ b/mock_ui_admin_center_v1/script.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const canvas = document.getElementById('statsCanvas');
+    if (!canvas.getContext) return;
+    const ctx = canvas.getContext('2d');
+
+    const data = [120, 90, 180, 75, 130];
+    const barWidth = 50;
+    const gap = 20;
+
+    data.forEach((value, index) => {
+        const x = index * (barWidth + gap);
+        const y = canvas.height - value;
+        ctx.fillStyle = '#4CAF50';
+        ctx.fillRect(x, y, barWidth, value);
+    });
+});

--- a/mock_ui_admin_center_v1/style.css
+++ b/mock_ui_admin_center_v1/style.css
@@ -1,0 +1,52 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: Arial, sans-serif;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+.top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #333;
+    color: #fff;
+    padding: 0 1rem;
+    height: 60px;
+}
+
+.container {
+    display: flex;
+    flex: 1;
+}
+
+.side-nav {
+    width: 200px;
+    background-color: #f4f4f4;
+    padding-top: 1rem;
+}
+
+.side-nav ul {
+    list-style: none;
+}
+
+.side-nav li {
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+}
+
+.side-nav li.active, .side-nav li:hover {
+    background-color: #ddd;
+}
+
+.content {
+    flex: 1;
+    padding: 1rem;
+    overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- add mock admin center layout with top bar, side navigation, and dashboard canvas example

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22892e60c832eba066c301c001a8a